### PR TITLE
Change .attrs format to non-deprecated format.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "lodash": "^4.17.11",
     "prop-types": "^15.6.2",
-    "styled-components": "^4.1.1"
+    "styled-components": "^4.1.2"
   },
   "peerDependencies": {
     "react": ">= 16.3.0",

--- a/src/Label/Label.jsx
+++ b/src/Label/Label.jsx
@@ -2,12 +2,12 @@ import get from 'lodash/get';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-export const Label = styled.div.attrs({
-  backgroundColor: ({ backgroundColor, theme }) => (
-    get(theme.colors, backgroundColor, backgroundColor)
-  ),
-  title: ({ children }) => children,
-})`
+export const Label = styled.div.attrs(
+  ({ backgroundColor, children, theme }) => ({
+    backgroundColor: get(theme.colors, backgroundColor, backgroundColor),
+    title: children,
+  }),
+)`
   display: inline-block;
   padding: 4px 6px;
   border-radius: 5px;


### PR DESCRIPTION
styled-components deprecated the individual functions for loading attributes favoring a single function for the entire `attrs` object. A bug after this was introduced kept the recommended approach from being able to be used with themes (styled-components/styled-components#2208) but that was fixed and released in styled-components@4.1.2.